### PR TITLE
Add finalizer permission to RB for OpenShift

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -105,9 +105,3 @@ rules:
   - get
   - update
   - patch
-- apiGroups:
-    - rbacmanager.reactiveops.io
-  resources:
-    - rbacdefinitions/finalizers
-  verbs:
-    - "*"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -73,6 +73,13 @@ rules:
   - update
   - patch
 - apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates/finalizers
+  - certificaterequests/finalizers
+  verbs:
+  - '*'
+- apiGroups:
   - ""
   resources:
   - events


### PR DESCRIPTION
Added to the manager ClusterRole so that finalizers don't trip us up on OpenShift

Tested on
- OpenShift 4.7.16 (v1.20.0+2817867)
- cert-manager 1.3.1
- kustomize 4.1.2